### PR TITLE
Add barebones implementation of Tito ticket sales widget

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,9 +8,12 @@
 		<meta name="description" content="Austin NodeBots Day, Come and join us! July 27th, 2014">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 
+		<script src='https://js.tito.io/v1' async></script>
+
 		<!-- Place favicon.ico and apple-touch-icon(s) in the root directory -->
 		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,800,700' rel='stylesheet' type='text/css'>
 		<link rel="stylesheet" href="css/main.css">
+		<link rel="stylesheet" type="text/css" href='https://css.tito.io/v1' />
 	</head>
 	<body>
 		<!--[if lt IE 9]>
@@ -88,7 +91,7 @@
 				<div class="container">
 					<h2 class="ticket-title">Tickets</h2>
 					<div class="ticket-options">
-						<p>Coming SOON!</p>
+						<tito-widget event="bocoup/roost-txjs-2015" releases="qgo2gzfkuza,l9kt2fqefmk"></tito-widget>
 					</div>
 				</div>
 			</section>


### PR DESCRIPTION
This adds the very basic implementation of the [Tito Widget](https://ti.to/docs/widget) to sell tickets on the site. The widget can do in-page checkout but that does not work on sites that are not HTTPS, so it will forward people to the tito checkout process. Widget styling can be updated more if you like! 

Let me know any thoughts/questions @nodebotanist,